### PR TITLE
Proposal: validation improvements for binary uploads (suggested for a new release branch)

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,5 +1,10 @@
 from flask import Blueprint, request, jsonify, send_file, after_this_request
-from .utils import convert_office_to_pdf, download_file
+from .utils import (
+    convert_office_to_pdf,
+    download_file,
+    detect_modern_office_type,
+    is_legacy_office_file,
+)
 from .constants import SUPPORTED_EXTENSIONS
 import tempfile
 import os
@@ -7,14 +12,19 @@ import time
 from werkzeug.utils import secure_filename
 import logging
 from urllib.parse import urlparse, unquote
-
+import shutil
 convert_bp = Blueprint("convert", __name__)
 logger = logging.getLogger(__name__)
+
+MODERN_EXTS = {"docx", "xlsx", "pptx"}
+LEGACY_EXTS = {"doc", "xls", "ppt"}
+
 
 def get_extension(filename: str) -> str:
     if not filename or "." not in filename:
         return ""
     return filename.rsplit(".", 1)[-1].lower()
+
 
 @convert_bp.route("/convert", methods=["POST"])
 def convert():
@@ -24,8 +34,15 @@ def convert():
     start_time = time.time()
 
     try:
-        method = request.form.get("method", "")
+        # method can come from header (binary) or form (multipart)
+        method = (
+            request.headers.get("method")
+            or request.form.get("method", "")
+        ).lower()
 
+        # =======================
+        # METHOD: file (multipart)
+        # =======================
         if method == "file":
             file = request.files.get("file")
             if not file or not file.filename:
@@ -35,27 +52,58 @@ def convert():
             if ext not in SUPPORTED_EXTENSIONS:
                 return jsonify({"error": "Invalid file format"}), 400
 
-            filename = secure_filename(file.filename)
-            original_filename = filename
+            original_filename = secure_filename(file.filename)
 
             with tempfile.NamedTemporaryFile(delete=False, suffix=f".{ext}") as temp_input:
                 file.save(temp_input.name)
                 temp_input_path = temp_input.name
 
-        # 'ms' (raw byte stream) method removed — accept only file uploads or URL
+        # =======================
+        # METHOD: ms (raw binary)
+        # =======================
         elif method == "ms":
             file_bytes = request.data
-            ext = request.form.get("ext", "docx").lower()
-
             if not file_bytes:
                 return jsonify({"error": "No byte stream provided"}), 400
 
-            if ext not in SUPPORTED_EXTENSIONS:
-                return jsonify({"error": "Invalid file format"}), 400
+            declared_ext = (
+                request.headers.get("X-File-Ext")
+                or request.form.get("ext")
+                or ""
+            ).lower().strip()
 
-            with tempfile.NamedTemporaryFile(delete=False, suffix=f".{ext}") as temp_input:
+            if declared_ext not in SUPPORTED_EXTENSIONS:
+                return jsonify({
+                    "error": "Invalid or missing file extension",
+                    "supported": sorted(SUPPORTED_EXTENSIONS),
+                }), 400
+
+            original_filename = f"document.{declared_ext}"
+
+            with tempfile.NamedTemporaryFile(delete=False, suffix=f".{declared_ext}") as temp_input:
                 temp_input.write(file_bytes)
                 temp_input_path = temp_input.name
+
+            # -------- validate content --------
+            if declared_ext in MODERN_EXTS:
+                detected = detect_modern_office_type(temp_input_path)
+                if detected != declared_ext:
+                    return jsonify({
+                        "error": "File content does not match declared extension",
+                        "declared": declared_ext,
+                        "detected": detected,
+                    }), 400
+
+            elif declared_ext in LEGACY_EXTS:
+                if not is_legacy_office_file(temp_input_path):
+                    return jsonify({
+                        "error": "Invalid legacy Office file",
+                        "declared": declared_ext,
+                    }), 400
+
+        # =======================
+        # METHOD: url
+        # =======================
         elif method == "url":
             file_url = request.form.get("fileUrl")
             if not file_url:
@@ -64,39 +112,53 @@ def convert():
             parsed = urlparse(file_url)
             raw_name = unquote(os.path.basename(parsed.path))
             filename = secure_filename(raw_name)
-            original_filename = filename
 
             ext = get_extension(filename)
             if ext not in SUPPORTED_EXTENSIONS:
                 return jsonify({"error": "Invalid file format"}), 400
 
+            original_filename = filename
             temp_input_path = download_file(file_url, filename)
 
         else:
             return jsonify({"error": "Invalid method provided"}), 400
 
-        logger.info(f"Received file, saved to: {temp_input_path}")
+        logger.info("Received file, saved to: %s", temp_input_path)
 
         if not temp_input_path or not os.path.exists(temp_input_path):
             return jsonify({"error": "Input file not available"}), 400
 
+        # =======================
+        # Convert
+        # =======================
         temp_output_path = convert_office_to_pdf(temp_input_path)
 
         if not temp_output_path or not os.path.exists(temp_output_path):
             return jsonify({"error": "Conversion failed: output missing"}), 500
-        # Cleanup handled in after_this_request
+
+        # =======================
+        # Cleanup temp files
+        # =======================
         @after_this_request
         def cleanup(response):
             try:
                 if temp_input_path and os.path.exists(temp_input_path):
                     os.remove(temp_input_path)
+
                 if temp_output_path and os.path.exists(temp_output_path):
+                    output_dir = os.path.dirname(temp_output_path)
                     os.remove(temp_output_path)
+
+                    if output_dir and os.path.isdir(output_dir):
+                        shutil.rmtree(output_dir, ignore_errors=True)
+
             except Exception:
                 logger.exception("Cleanup failed")
             return response
-
-        # use original filename but with .pdf extension for download
+        logger.info("Scheduled cleanup of temp files")
+        # =======================
+        # Download filename
+        # =======================
         if original_filename:
             base = os.path.splitext(original_filename)[0]
             download_name = secure_filename(f"{base}.pdf")
@@ -115,4 +177,4 @@ def convert():
 
     finally:
         duration = time.time() - start_time
-        logger.info(f"Request processed in {duration:.2f} seconds")
+        logger.info("Request processed in %.2f seconds", duration)

--- a/app/utils.py
+++ b/app/utils.py
@@ -10,7 +10,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from .constants import SUPPORTED_EXTENSIONS
 import zipfile
-
+from typing import Optional
 logger = logging.getLogger(__name__)
 time_logger = logger
 
@@ -23,7 +23,7 @@ def _ensure_soffice():
 
 
 # Detect modern Office type by inspecting ZIP content
-def detect_modern_office_type(file_path: str) -> str | None:
+def detect_modern_office_type(file_path: str) -> Optional[str]:
     try:
         with zipfile.ZipFile(file_path, mode="r") as z:
             names = set(z.namelist())


### PR DESCRIPTION
Hi @beladevo 👋  

⚠️ This PR is **not intended to be merged into `main` directly**.  
It is proposed as a candidate for a **new release / feature branch** (e.g. `release-1.1`).

---

## Background

The existing `method=ms` endpoint accepts raw binary uploads but previously relied
only on a client-provided extension (`ext`) without validating the actual file content.

This allowed cases where:
- A client declares `ext=docx` but uploads a different Office format
- A non-Office binary is passed through to LibreOffice
- Extension spoofing could lead to unexpected behavior or crashes

This PR improves **security, correctness, and clarity** of the `method=ms` API
while remaining backward-compatible at the HTTP level.

---

## Updated `method=ms` contract

### Request format

- **HTTP Method:** `POST /convert`
- **Content-Type:** `application/octet-stream`
- **Body:** raw binary Office file
- **Required metadata:**
  - `method: ms` (HTTP header or form field)
  - File extension provided via:
    - `X-File-Ext` HTTP header (recommended), or
    - `ext` form field (fallback)

### Example
```
curl --location --request POST 'http://localhost:8000/convert' \
--header 'method: ms' \
--header 'Content-Type: application/octet-stream' \
--header 'X-File-Ext: doc' \
--data-binary '@/D:/📝 Draft Release Note.doc'
```

Summary of changes:
- Improve validation for `method=ms` raw binary uploads
- Prevent extension spoofing by validating file content
- Support full Office formats: doc/docx, xls/xlsx, ppt/pptx
- Validate modern Office files via internal ZIP structure
- Validate legacy Office files via OLE header
- Improve temporary file cleanup

No breaking changes to existing APIs.

If you agree, I can:
- Rebase or adapt this PR to a new branch you prefer
- Split it further if needed

Thanks for reviewing!

